### PR TITLE
CI: Drop unused Travis directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.3.7


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details