### PR TITLE
CI: Update matrix, 2.3.8, 2.4.6, 2.5.6, 2.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.3
-  - 2.5.1
+  - 2.3.8
+  - 2.4.6
+  - 2.5.6
+  - 2.6.4
 before_install: gem install bundler -v 1.16.1


### PR DESCRIPTION
This PR updates the build matrix.

https://www.ruby-lang.org/en/news/2019/08/28/multiple-jquery-vulnerabilities-in-rdoc/ links to the releases. 

rvm seems not to distribute 2.4.7 yet, so that is excluded here.