### PR TITLE
CI: Try adding Ruby CI: Use 2.4.9, 2.5.7, 2.6.5 to the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.3.8
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 before_install: gem install bundler -v 1.16.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.3.8
-  - 2.4.6
+  - 2.4.7
   - 2.5.6
   - 2.6.4
 before_install: gem install bundler -v 1.16.1


### PR DESCRIPTION
This PR adds a new matrix item.

Ruby 2.4.7 was perhaps not available, maybe.

**Update**: not yet available

<details>

```
$ rvm use 2.4.7 --install --binary --fuzzy

curl: (22) The requested URL returned error: 404 Not Found

Required ruby-2.4.7 is not installed - installing.

curl: (22) The requested URL returned error: 404 Not Found

Searching for binary rubies, this might take some time.

Requested binary installation but no rubies are available to download, consider skipping --binary flag.

Gemset '' does not exist, 'rvm ruby-2.4.7 do rvm gemset create ' first, or append '--create'.

The command "rvm use 2.4.7 --install --binary --fuzzy" failed and exited with 2 during .
```

</details>