### PR TITLE
Add support for lots more query methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,19 @@ Post.where { title.matches("foo").and(content.matches("bar")) }
 Wharel will map `title` and `content` in the block to the appropriate Arel
 attribute for the column.
 
-Works with `where.not` too:
+Wharel also supports most other query methods, e.g. `not`:
 
 ```ruby
 Post.where.not { title.eq("foo") }
 ```
 
-... and also with `order`:
+... and `order`:
 
 ```ruby
 Post.order { title.lower }
 ```
+
+Wharel also supports `having`, `pluck`, `group` and `or` in the same way.
 
 Now suppose we have another model `Comment` with a column `content`, and a
 `Post` `has_many :comments`:

--- a/lib/wharel.rb
+++ b/lib/wharel.rb
@@ -3,12 +3,16 @@ require "active_record"
 
 module Wharel
   module QueryMethods
-    def where(opts = :chain, *rest, &block)
-      block_given? ? super(VirtualRow.build_query(self, &block)) : super
+    %w[where order having pluck group].each do |method_name|
+      module_eval <<-EOM, __FILE__, __LINE__ + 1
+      def #{method_name}(*, &block)
+        block_given? ? super(VirtualRow.build_query(self, &block)) : super
+      end
+      EOM
     end
 
-    def order(*args, &block)
-      block_given? ? super(VirtualRow.build_query(self, &block)) : super
+    def or(*, &block)
+      block_given? ? super(model.where(VirtualRow.build_query(self, &block))) : super
     end
 
     module WhereChain

--- a/spec/wharel_spec.rb
+++ b/spec/wharel_spec.rb
@@ -48,12 +48,78 @@ RSpec.describe Wharel do
   end
 
   describe "Relation#order" do
-    it "works with block format" do
-      post1 = Post.create(title: "Z")
-      post2 = Post.create(title: "a")
+    let!(:post1) { Post.create(title: "Z") }
+    let!(:post2) { Post.create(title: "a") }
 
+    it "works with block format" do
       expect(Post.order { title }).to eq([post1, post2])
       expect(Post.order { title.lower }).to eq([post2, post1])
+    end
+
+    it "works without block format" do
+      expect(Post.order(:title)).to eq([post1, post2])
+      expect(Post.order("LOWER(title)")).to eq([post2, post1])
+    end
+  end
+
+  describe 'grouping query methods' do
+    let!(:post1) { Post.create(title: 'foo', content: 'baz') }
+    let!(:post2) { Post.create(title: 'bar', content: 'baz') }
+    let!(:post3) { Post.create(title: 'Foo', content: 'baz') }
+
+    describe 'Relation#group' do
+      it 'works with block format' do
+        expect(Post.group { title.lower }.map { |p| p.title.downcase }).to match_array(%w[foo bar])
+      end
+
+      it 'works without block format' do
+        expect(Post.group(:title).map(&:title)).to match_array(%w[foo Foo bar])
+      end
+    end
+
+    describe 'Relation#having' do
+      it 'works with block format' do
+        expect(
+          Post.group(:title).having { title.lower.eq('foo') }.map(&:title)
+        ).to match_array(%w[foo Foo])
+      end
+
+      it 'works without block format' do
+        expect(
+          Post.group(:title).having("LOWER(title) = ?", 'foo').map(&:title)
+        ).to match_array(%w[foo Foo])
+      end
+    end
+  end
+
+  describe 'Relation#pluck' do
+    let!(:post1) { Post.create(title: 'foo') }
+    let!(:post2) { Post.create(title: 'bar') }
+    let!(:post3) { Post.create(title: 'Foo') }
+
+    it 'works with block format' do
+      expect(Post.pluck { title.lower }).to match_array(%w[foo bar foo])
+    end
+
+    it 'works without block format' do
+      expect(Post.pluck("LOWER(title)")).to match_array(%w[foo bar foo])
+    end
+  end
+
+  describe 'Relation#or' do
+    let!(:post1) { Post.create(title: 'This Wharel!') }
+    let!(:post2) { Post.create(title: 'Not this Wharel!') }
+
+    it 'works with block format' do
+      expect(
+        Post.where { title.eq('This Wharel!') }.or { title.eq('Not this Wharel!') }
+      ).to match_array([post1, post2])
+    end
+
+    it 'works without block format' do
+      expect(
+        Post.where(title: 'This Wharel!').or(Post.where(title: 'Not this Wharel!'))
+      ).to match_array([post1, post2])
     end
   end
 


### PR DESCRIPTION
It occurred to me that Wharel could very easily support all kinds of other query methods which actually accept Arel node arguments, so here I've done that. With this change, in addition to `where`, `not` and `order` (added yesterday), you can now also pass blocks to `having`, `pluck`, `group` and even `or`.