### PR TITLE
ActiveRecord 6 support, select, pick

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Post.where.not { title.eq("foo") }
 Post.order { title.lower }
 ```
 
-Wharel also supports `select`, `having`, `pluck`, `group` and `or` in the same way.
+Wharel also supports `select`, `having`, `pluck`, `pick`, `group` and `or` in the same way.
 
 Now suppose we have another model `Comment` with a column `content`, and a
 `Post` `has_many :comments`:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Post.where.not { title.eq("foo") }
 Post.order { title.lower }
 ```
 
-Wharel also supports `having`, `pluck`, `group` and `or` in the same way.
+Wharel also supports `select`, `having`, `pluck`, `group` and `or` in the same way.
 
 Now suppose we have another model `Comment` with a column `content`, and a
 `Post` `has_many :comments`:

--- a/lib/wharel.rb
+++ b/lib/wharel.rb
@@ -3,7 +3,9 @@ require "active_record"
 
 module Wharel
   module QueryMethods
-    %w[select where order having pluck group].each do |method_name|
+    %w[select where order having pluck pick group].each do |method_name|
+      next unless ::ActiveRecord::Base.singleton_class.method_defined?(method_name)
+
       module_eval <<-EOM, __FILE__, __LINE__ + 1
       def #{method_name}(*, &block)
         block_given? ? super(VirtualRow.build_query(self, &block), &nil) : super

--- a/lib/wharel.rb
+++ b/lib/wharel.rb
@@ -3,10 +3,10 @@ require "active_record"
 
 module Wharel
   module QueryMethods
-    %w[where order having pluck group].each do |method_name|
+    %w[select where order having pluck group].each do |method_name|
       module_eval <<-EOM, __FILE__, __LINE__ + 1
       def #{method_name}(*, &block)
-        block_given? ? super(VirtualRow.build_query(self, &block)) : super
+        block_given? ? super(VirtualRow.build_query(self, &block), &nil) : super
       end
       EOM
     end

--- a/spec/wharel_spec.rb
+++ b/spec/wharel_spec.rb
@@ -119,6 +119,20 @@ RSpec.describe Wharel do
     end
   end
 
+  if ActiveRecord::VERSION::MAJOR >= 6
+    describe "Relation#pick" do
+      let!(:post) { Post.create(title: "Foo") }
+
+      it "works with block format" do
+        expect(Post.pick { title.lower }).to eq("foo")
+      end
+
+      it "works without block format" do
+        expect(Post.pick("LOWER(title)")).to eq("foo")
+      end
+    end
+  end
+
   describe 'Relation#or' do
     let!(:post1) { Post.create(title: 'This Wharel!') }
     let!(:post2) { Post.create(title: 'Not this Wharel!') }

--- a/spec/wharel_spec.rb
+++ b/spec/wharel_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe Wharel do
     end
   end
 
+  describe "Relation#select" do
+    let!(:post1) { Post.create(title: "foo", content: "baz") }
+    let!(:post2) { Post.create(title: "Bar", content: "baz") }
+
+    it "works with block format" do
+      expect(Post.select { title.lower.as("title") }.map(&:title)).to match_array(%w[foo bar])
+    end
+
+    it "works without block format" do
+      expect(Post.select(:title).map(&:title)).to match_array(%w[foo Bar])
+    end
+  end
+
   describe "Relation#where" do
     it "works with block format" do
       Post.create # shouldn't match this one!

--- a/wharel.gemspec
+++ b/wharel.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activerecord', '>= 5', '<= 6'
+  spec.add_dependency 'activerecord', '>= 5', '<= 6.1'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "sqlite3", '>= 1.3', '< 1.5'


### PR DESCRIPTION
This pull request adds support for ActiveRecord `~> 6.1` and support for `Post.select { title.lower }` and `Post.pick { title.lower }`. If necessary I can split the commits into separate pull requests.

Thankyou :slightly_smiling_face: